### PR TITLE
Adds a task to publish artifacts to JFrog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,13 @@ This repository is open source and available under the MIT license. For more inf
 [apiExplorer.paymentMethods]: https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v46/paymentMethods
 [apiExplorer.payments]: https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v46/payments
 [apiExplorer.paymentsDetails]: https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v46/paymentsDetails
+
+
+# Publish artifactory to JFrog
+```
+ ./gradlew clean :drop-in:artifactoryPublish -Pcurrent_version='<VERSION>' -Partifactory_user='<USER>' -Partifactory_password='<PASSWORD>'
+```
+
+_NOTE:_ Use single quotes for parameters.
+
+Check the new version at https://spin.jfrog.io/artifactory/default-maven-local/com/adyen/checkout/spin-drop-in

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ buildscript {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintray_gradle_plugin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detekt_gradle_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_gradle_plugin_version"
+
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:latest.release"
     }
 }
 

--- a/config/gradle/release.gradle
+++ b/config/gradle/release.gradle
@@ -10,6 +10,7 @@ import groovy.json.JsonSlurper
 
 apply plugin: "maven-publish"
 apply plugin: "com.jfrog.bintray"
+apply plugin: "com.jfrog.artifactory"
 
 apply from: "../config/gradle/artifacts.gradle"
 
@@ -17,7 +18,7 @@ apply from: "../config/gradle/artifacts.gradle"
 
 final theGroupId = "com.adyen.checkout"
 final theArtifactId = project.mavenArtifactId
-final theVersion = project.version_name
+final theVersion = "${current_version}"
 
 final theName = project.mavenArtifactName
 final theDescription = project.mavenArtifactDescription
@@ -103,6 +104,29 @@ project.afterEvaluate {
                     configurations.implementation.dependencies.each { dep -> addDependency(dep, "runtime") }
                 }
             }
+        }
+    }
+
+    artifactoryPublish {
+        publications(publishing.publications.bintrayMavenPublication)
+    }
+}
+
+
+artifactory {
+    contextUrl = 'https://spin.jfrog.io/artifactory'
+    publish {
+        repository {
+            repoKey = 'default-maven-local' // The Artifactory repository key to publish to
+            username = "${artifactory_user}" // The publisher user name
+            password = "${artifactory_password}" // The publisher password
+        }
+        defaults {
+            // Reference to Gradle publications defined in the build script.
+            // This is how we tell the Artifactory Plugin which artifacts should be
+            // published to Artifactory.
+            publishArtifacts = true
+            publishPom = true // Publish generated POM files to Artifactory (true by default)
         }
     }
 }

--- a/drop-in/build.gradle
+++ b/drop-in/build.gradle
@@ -7,7 +7,7 @@
  */
 
 // Maven artifact
-ext.mavenArtifactId = "drop-in"
+ext.mavenArtifactId = "spin-drop-in"
 ext.mavenArtifactName = "Adyen checkout drop-in component"
 ext.mavenArtifactDescription = "Adyen checkout drop-in component client for Adyen's Checkout API."
 


### PR DESCRIPTION
## Description
A JFrog account was created to allow us publish artifacts.
Ask @nickoneill for credentials.

## How to publish to JFrog
Check documentation https://github.com/spin-org/adyen-android/blob/8c6dbe8f04f2147e9132abda654d236c4f3722d7/README.md#publish-artifactory-to-jfrog

```
 ./gradlew clean :drop-in:artifactoryPublish -Pcurrent_version='<VERSION>' -Partifactory_user='<USER>' -Partifactory_password='<PASSWORD>'
```