### PR TITLE
Use version 4.0.0 instead of 4.0.0-beta03

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "4.0.0-beta03"
+    ext.version_name = "4.0.0"
 
     // Code quality
     ext.ktlint_version = '0.40.0'


### PR DESCRIPTION
Hi Joe, could you please take a look at this? I just updated the version to 4.0.0 so we do not have to use a beta version in the react-native-payments library. Now we are going to use spin-drop-in:4.0.0-spin instead of spin-drop-in:4.0.0-beta03-spin