### PR TITLE
Make postal code valid if it’s empty when not required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "4.1.0-spin"
+    ext.version_name = "4.1.0-spin01"
 
     // Code quality
     ext.ktlint_version = '0.40.0'

--- a/card/src/main/java/com/adyen/checkout/card/NewCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/NewCardDelegate.kt
@@ -110,10 +110,10 @@ class NewCardDelegate(
     }
 
     override fun validatePostalCode(postalCode: String): FieldState<String> {
-        val validation = if (postalCode.isNotEmpty()) {
-            Validation.Valid
-        } else {
+        val validation = if (isPostalCodeRequired() && postalCode.isEmpty()) {
             Validation.Invalid(R.string.checkout_card_postal_not_valid)
+        } else {
+            Validation.Valid
         }
         return FieldState(postalCode, validation)
     }


### PR DESCRIPTION
@zhentan  could you please check this, it makes the postal code valid when it is not required and it the field is empty.

When the postal code was empty the library was taking it as invalid and this was preventing us from hiding this field.